### PR TITLE
Modernize dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.0.0', :engine => 'jruby', :engine_version => '1.7.27'
+ruby '2.5.7', :engine => 'jruby', :engine_version => '9.2.9.0'
 
 gem 'addressable', '2.3.6'
-gem 'transit-ruby', '0.8.572'
-gem 'naether', '0.13.8'
+gem 'naether', '0.15.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,22 +2,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
-    lock_jar (0.10.4)
-      naether (~> 0.13.8)
-      thor (>= 0.18.1)
-    naether (0.13.8-java)
-    thor (0.20.0)
-    transit-ruby (0.8.572-java)
-      addressable (~> 2.3.6)
-      lock_jar (~> 0.10.0)
+    httpclient (2.8.3)
+    naether (0.15.7-java)
+      httpclient
+      rake (< 11.0)
+    rake (10.5.0)
 
 PLATFORMS
   java
 
 DEPENDENCIES
   addressable (= 2.3.6)
-  naether (= 0.13.8)
-  transit-ruby (= 0.8.572)
+  naether (= 0.15.7)
+
+RUBY VERSION
+   ruby 2.5.7p0 (jruby 9.2.9.0)
 
 BUNDLED WITH
-   1.15.4
+   2.1.4


### PR DESCRIPTION
This fixes Maven Central HTTPS errors and should still test the same things as before.